### PR TITLE
Update schedule config for reception (skip existing)

### DIFF
--- a/news/URB-3005.bugfix
+++ b/news/URB-3005.bugfix
@@ -1,0 +1,2 @@
+Update schedule config for reception (skip existing)
+[daggelpop]

--- a/src/urban/schedule/profiles/config/standard/codt_buildlicence/reception.json
+++ b/src/urban/schedule/profiles/config/standard/codt_buildlicence/reception.json
@@ -230,8 +230,8 @@
     "@type": "TaskConfig",
     "UID": "9cea6ad87cdd4d8ca0e03d499290ca3f",
     "activate_recurrency": true,
-    "additional_delay": null,
-    "additional_delay_type": null,
+    "additional_delay": "0",
+    "additional_delay_type": "absolute",
     "allow_discussion": false,
     "calculation_delay": [
         "schedule.calculation_default_delay"

--- a/src/urban/schedule/profiles/config/standard/codt_urbancertificatetwo/reception.json
+++ b/src/urban/schedule/profiles/config/standard/codt_urbancertificatetwo/reception.json
@@ -229,8 +229,8 @@
     "@type": "TaskConfig",
     "UID": "75c0737c07da4c0e9c1288cd6d359d69",
     "activate_recurrency": false,
-    "additional_delay": null,
-    "additional_delay_type": null,
+    "additional_delay": "0",
+    "additional_delay_type": "absolute",
     "allow_discussion": false,
     "calculation_delay": [
         "schedule.calculation_default_delay"

--- a/src/urban/schedule/profiles/default/metadata.xml
+++ b/src/urban/schedule/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata>
-  <version>1003</version>
+  <version>1004</version>
   <dependencies>
   </dependencies>
 </metadata>

--- a/src/urban/schedule/profiles/default/metadata.xml
+++ b/src/urban/schedule/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata>
-  <version>1004</version>
+  <version>1005</version>
   <dependencies>
   </dependencies>
 </metadata>

--- a/src/urban/schedule/upgrades.py
+++ b/src/urban/schedule/upgrades.py
@@ -35,3 +35,16 @@ def update_fd_opinion(context):
     else:
         logger.info("nothing to upgrade")
     logger.info("upgrade done!")
+
+
+def update_reception_skip_existing(context):
+    logger.info("starting : Update reception tasks (skip existing)")
+    if "standard" in utils.get_configs():
+        utils.import_all_config(
+            base_json_path="./profiles/config/standard",
+            handle_existing_content=utils.ExistingContent.SKIP,
+            match_filename="reception.json",
+        )
+    else:
+        logger.info("nothing to upgrade")
+    logger.info("upgrade done!")

--- a/src/urban/schedule/upgrades.zcml
+++ b/src/urban/schedule/upgrades.zcml
@@ -30,4 +30,13 @@
       profile="urban.schedule:default"
       />
 
+  <genericsetup:upgradeStep
+      title="Update schedule config for reception (skip existing)"
+      description=""
+      source="1003"
+      destination="1004"
+      handler="urban.schedule.upgrades.update_reception_skip_existing"
+      profile="urban.schedule:default"
+      />
+
 </configure>


### PR DESCRIPTION
Needed to import some reception tasks.

They were not imported before because of a split of commits between 2 Urban releases.

CAUTION: 

1. Task `attente_plans_modifies` needs workflow state `suspension` for its creation.
2. This workflow state is imported in Products.urban 2.7.14 (server.urban 2.7.17).
3. Therefore, upgrades steps in Products.urban 2.7.14 must run before the upgrade step in this commit.